### PR TITLE
Revert to previous set up where clinvar accession is called separately for two running modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,12 @@ eggd_pandora is a variant sharing system, which takes in variant data from a sou
 * `--clinvar_testing`: (bool) whether or not to use the ClinVar test endpoint (True) or live endpoint (False)
 ### ClinVar accession
 * `--clinvar_api_key`: (file) File containing ClinVar API key
-* `--submission_file `: (file) File containing ClinVar submission ID
+* `--submission_ids_file `: (file) File containing ClinVar submission IDs. Example format
+```
+    Local_ID    Submission_ID
+    uid_1707758278575948778 SUB14474946
+    uid_1707745813424903959 SUB14471647
+```
 
 
 ## How does this app work?

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ eggd_pandora is a variant sharing system, which takes in variant data from a sou
 * `--clinvar_api_key`: (file) File containing ClinVar API key
 * `--submission_ids_file `: (file) File containing ClinVar submission IDs. Example format
 ```
-    Local_ID    Submission_ID
+    Local_ID    ClinVar_Submission_ID
     uid_1707758278575948778 SUB14474946
     uid_1707745813424903959 SUB14471647
 ```

--- a/resources/home/dnanexus/get_clinvar_accession.py
+++ b/resources/home/dnanexus/get_clinvar_accession.py
@@ -112,7 +112,7 @@ def write_accession_id_to_file(local_id, accession):
     if not os.path.exists('accession_ids.txt'):
         with open('accession_ids.txt', 'a', encoding='utf-8') as f:
             f.write(
-                'Local_ID\tClinVar_Submission_ID\n'
+                'Local_ID\tClinVar_Accession_ID\n'
             )
 
     with open('accession_ids.txt', 'a', encoding='utf-8') as f:

--- a/resources/home/dnanexus/get_clinvar_accession.py
+++ b/resources/home/dnanexus/get_clinvar_accession.py
@@ -48,11 +48,12 @@ def submission_status_check(submission_id, headers, api_url):
         )
         try:
             f_url = responses[0]["files"][0]["url"]
-        except KeyError:
+        except (KeyError, IndexError) as error:
             f_url = None
             print(
-                "No API url for summary file found. Cannot query API for"
-                f" summary file based on response {responses}"
+                f"Error retrieving files: {error}.\n No API url for summary"
+                "file found. Cannot query API for summary file based on "
+                f"response {responses}"
             )
 
         if f_url is not None:

--- a/resources/home/dnanexus/get_clinvar_accession.py
+++ b/resources/home/dnanexus/get_clinvar_accession.py
@@ -181,7 +181,7 @@ def main():
         for index, row in df.iterrows():
             run_submission_status_check(
                 row["Local_ID"],
-                row["Submission_ID"],
+                row["ClinVar_Submission_ID"],
                 headers,
                 api_url
             )

--- a/src/pandora.sh
+++ b/src/pandora.sh
@@ -39,7 +39,8 @@ then
 
     python3 /home/dnanexus/get_clinvar_accession.py \
     --submission_file /home/dnanexus/out/clinvar_submission_id/submission_ids.txt \
-    --clinvar_api_key /home/dnanexus/in/clinvar_api_key/*.txt
+    --clinvar_api_key /home/dnanexus/in/clinvar_api_key/*.txt \
+    --clinvar_testing $clinvar_testing
     mkdir /home/dnanexus/out/clinvar_accession_id
     mv accession_ids.txt /home/dnanexus/out/clinvar_accession_id
     dx-upload-all-outputs
@@ -48,7 +49,8 @@ then
     pip install pandas
     python3 /home/dnanexus/get_clinvar_accession.py \
         --submission_file /home/dnanexus/in/submission_ids_file/* \
-        --clinvar_api_key /home/dnanexus/in/clinvar_api_key/*.txt
+        --clinvar_api_key /home/dnanexus/in/clinvar_api_key/*.txt \
+        --clinvar_testing $clinvar_testing
     mkdir /home/dnanexus/out/clinvar_accession_id
     mv accession_ids.txt /home/dnanexus/out/clinvar_accession_id
     dx-upload-all-outputs

--- a/src/pandora.sh
+++ b/src/pandora.sh
@@ -4,14 +4,6 @@ set -exo pipefail #if any part goes wrong, job will fail
 pip install pytest
 dx-download-all-inputs
 
-# Check if running_mode is valid
-if [[ "clinvar decipher get_clinvar_accession" =~ \ $running_mode\  ]]
-then
-    echo Running mode $running_mode is not valid please choose one of the following:
-    echo 'clinvar', 'decipher', 'get_clinvar_accession'
-    exit 1
-fi
-
 # Run python scripts based on running_mode
 if [ "$running_mode" = "decipher" ]
 then
@@ -29,8 +21,7 @@ then
     DECIPHER_URL=$(cat decipher_url.txt)
 
     dx-jobutil-add-output link_to_patient_in_decipher "$DECIPHER_URL" --class=string
-fi
-if [ "$running_mode" = "clinvar" ]
+elif [ "$running_mode" = "clinvar" ]
 then
     pip install pandas
     python3 /home/dnanexus/pull_from_csv.py \
@@ -45,15 +36,25 @@ then
     done
     mkdir -p /home/dnanexus/out/clinvar_submission_id
     mv submission_ids.txt /home/dnanexus/out/clinvar_submission_id
-fi
-if [[ "clinvar get_clinvar_accession" =~ \ $running_mode\  ]]
+
+    python3 /home/dnanexus/get_clinvar_accession.py \
+    --submission_file /home/dnanexus/out/clinvar_submission_id/submission_ids.txt \
+    --clinvar_api_key /home/dnanexus/in/clinvar_api_key/*.txt
+    mkdir /home/dnanexus/out/clinvar_accession_id
+    mv accession_ids.txt /home/dnanexus/out/clinvar_accession_id
+    dx-upload-all-outputs
+elif [ "$running_mode" = "get_clinvar_accession" ]
 then
     pip install pandas
     python3 /home/dnanexus/get_clinvar_accession.py \
-        --submission_file /home/dnanexus/out/submission_id/submission_ids.txt \
+        --submission_file /home/dnanexus/in/submission_ids_file/* \
         --clinvar_api_key /home/dnanexus/in/clinvar_api_key/*.txt
     mkdir /home/dnanexus/out/clinvar_accession_id
     mv accession_ids.txt /home/dnanexus/out/clinvar_accession_id
     dx-upload-all-outputs
+else
+    echo Running mode $running_mode is not valid please choose one of the following:
+    echo 'clinvar', 'decipher', 'get_clinvar_accession'
+    exit 1
 fi
 

--- a/src/pandora.sh
+++ b/src/pandora.sh
@@ -51,7 +51,7 @@ then
         --submission_file /home/dnanexus/in/submission_ids_file/* \
         --clinvar_api_key /home/dnanexus/in/clinvar_api_key/*.txt \
         --clinvar_testing $clinvar_testing
-    mkdir /home/dnanexus/out/clinvar_accession_id
+    mkdir -p /home/dnanexus/out/clinvar_accession_id
     mv accession_ids.txt /home/dnanexus/out/clinvar_accession_id
     dx-upload-all-outputs
 else


### PR DESCRIPTION
Example job using this version: https://platform.dnanexus.com/panx/projects/Gk7Q4x84XPvBZPYBxVyk2v14/monitor/job/Gk866Pj4XPv9yZ8ZxGPX05fV

Submission made by this job in ClinVar
![image](https://github.com/eastgenomics/eggd_pandora/assets/71272357/a4293eba-643c-40f4-9955-c5454a072abf)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_pandora/3)
<!-- Reviewable:end -->
