### PR TITLE
rename variable to match API

### DIFF
--- a/resources/home/dnanexus/pull_from_csv.py
+++ b/resources/home/dnanexus/pull_from_csv.py
@@ -162,7 +162,7 @@ def add_nuh_id(organisation_id, clinvar_dict):
     '''
     # If NUH
     if organisation_id == 509428:
-        clinvar_dict['behalfOfID'] = organisation_id
+        clinvar_dict['behalfOrgID'] = organisation_id
     # If CUH, no changes need to be made
     elif organisation_id == 288359:
         pass

--- a/resources/home/dnanexus/tests/test_pandora.py
+++ b/resources/home/dnanexus/tests/test_pandora.py
@@ -423,9 +423,9 @@ class TestCSV:
 
     def test_nuh_org_id_added(self):
         """
-        Test that behalfOfID field is added if organisation is NUH
+        Test that behalfOrgID field is added if organisation is NUH
         """
-        assert add_nuh_id(509428, {}) == {"behalfOfID": 509428}
+        assert add_nuh_id(509428, {}) == {"behalfOrgID": 509428}
 
     def test_no_change_if_cuh(self):
         """


### PR DESCRIPTION
 'behalfOfId' field in pandora should be written as  'behalfOrgId'  to match API
Job using updated version:
https://platform.dnanexus.com/panx/projects/Gg2G26Q409xJXX3Ky8xx3Vqy/monitor/job/GkZjZJQ409x2jx8PK4pY344Z
Logs showing field name change:
![image](https://github.com/eastgenomics/eggd_pandora/assets/71272357/4f06d9da-03ae-4da5-8603-c89cd93636a9)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_pandora/4)
<!-- Reviewable:end -->
